### PR TITLE
solve issue of low contrast

### DIFF
--- a/KnightsOfAlentejoAndroid-AS/app/src/main/res/layout/howtoplay_layout.xml
+++ b/KnightsOfAlentejoAndroid-AS/app/src/main/res/layout/howtoplay_layout.xml
@@ -33,7 +33,7 @@
                     android:layout_height="wrap_content"
                     android:text="@string/how_to_play1"
                     android:textAppearance="?android:attr/textAppearanceMedium"
-                    android:textColor="#000"/>
+                    android:textColor="#282828"/>
 
                 <TextView
                     android:id="@+id/textView2"
@@ -70,7 +70,7 @@
                                 android:layout_height="wrap_content"
                                 android:text="@string/turtle_knight"
                                 android:textAppearance="?android:attr/textAppearanceMedium"
-                                android:textColor="#f00"/>
+                                android:textColor="#B40000"/>
 
                             <TextView
                                 android:id="@+id/textView6"
@@ -104,7 +104,7 @@
                                 android:layout_height="wrap_content"
                                 android:text="@string/bull_knight"
                                 android:textAppearance="?android:attr/textAppearanceMedium"
-                                android:textColor="#f00"/>
+                                android:textColor="#B40000"/>
 
                             <TextView
                                 android:id="@+id/textView7"
@@ -138,7 +138,7 @@
                                 android:layout_height="wrap_content"
                                 android:text="@string/falcon_knight"
                                 android:textAppearance="?android:attr/textAppearanceMedium"
-                                android:textColor="#f00"/>
+                                android:textColor="#DC0000"/>
 
                             <TextView
                                 android:id="@+id/textView8"
@@ -180,7 +180,7 @@
                                 android:layout_height="wrap_content"
                                 android:text="@string/entry"
                                 android:textAppearance="?android:attr/textAppearanceMedium"
-                                android:textColor="#f00"/>
+                                android:textColor="#DC0000"/>
 
                             <TextView
                                 android:id="@+id/textView12"
@@ -214,7 +214,7 @@
                                 android:layout_height="wrap_content"
                                 android:text="@string/exit"
                                 android:textAppearance="?android:attr/textAppearanceMedium"
-                                android:textColor="#f00"/>
+                                android:textColor="#DC0000"/>
 
                             <TextView
                                 android:id="@+id/textView13"

--- a/KnightsOfAlentejoAndroid-AS/app/src/main/res/layout/main.xml
+++ b/KnightsOfAlentejoAndroid-AS/app/src/main/res/layout/main.xml
@@ -26,7 +26,7 @@
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:text="@string/app_name"
             android:id="@+id/tvTitle"
-            android:textColor="#F00"
+            android:textColor="#141414"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:layout_alignParentStart="false"


### PR DESCRIPTION
The original text color of the component is '#FFFFFF', and the contrast between the text color ('#FFFFFF') and the background color ('#9E9E9E') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#282828') are as follows:
![image](https://user-images.githubusercontent.com/101503193/167421480-3a4dc903-4af5-4ba6-9553-98bedeee6627.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.

And the followings are similar with the example above:
![image](https://user-images.githubusercontent.com/101503193/167422026-83f26ce4-8e99-4b9e-b54c-d4ae4396f5f8.png)
